### PR TITLE
Ioc 225

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,9 +20,9 @@ jobs:
             goos: windows
     steps:
     - uses: actions/checkout@v3
-    - uses: wangyoucao577/go-release-action@v1.37
+    - uses: wangyoucao577/go-release-action@v1.40
       with:
-        asset_name: gu-${{ github.ref_name }}-${{ matrix.goos }}-${{ matrix.goarch }}
+        asset_name: io-${{ github.ref_name }}-${{ matrix.goos }}-${{ matrix.goarch }}
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: ${{ matrix.goos }}
         goarch: ${{ matrix.goarch }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes in io-sdk-golang will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.3.3] - 2023-11-15
+
+- Exposing API errors in order to support consumers performing status checks
+- Updated build automation manifest for CLI tool
+
 ## [0.3.2] - 2023-11-13
 
 - Updated `customer` market sub model to include code field

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SEMANTIC_VER=0.3.2+
+SEMANTIC_VER=0.3.3+
 BUILD_VER=$(shell git describe --always --long)
 PRE_RELEASE_VER=alpha
 

--- a/pkg/api/childEndpoints_test.go
+++ b/pkg/api/childEndpoints_test.go
@@ -82,7 +82,7 @@ func TestChildEndpoint_Create(t *testing.T) {
 					w.WriteHeader(http.StatusBadRequest)
 					w.Header().Set("Content-Type", "application/json")
 
-					err := apiError{
+					err := APIError{
 						Message: "test-error-message",
 						Status:  http.StatusBadRequest,
 						Title:   "test-error-title",
@@ -181,7 +181,7 @@ func TestChildEndpoint_Delete(t *testing.T) {
 					w.WriteHeader(http.StatusBadRequest)
 					w.Header().Set("Content-Type", "application/json")
 
-					err := apiError{
+					err := APIError{
 						Message: "test-error-message",
 						Status:  http.StatusBadRequest,
 						Title:   "test-error-title",
@@ -283,7 +283,7 @@ func TestChildEndpoint_Get(t *testing.T) {
 					w.WriteHeader(http.StatusBadRequest)
 					w.Header().Set("Content-Type", "application/json")
 
-					err := apiError{
+					err := APIError{
 						Message: "test-error-message",
 						Status:  http.StatusBadRequest,
 						Title:   "test-error-title",
@@ -396,7 +396,7 @@ func TestChildEndpoint_Patch(t *testing.T) {
 					w.WriteHeader(http.StatusBadRequest)
 					w.Header().Set("Content-Type", "application/json")
 
-					err := apiError{
+					err := APIError{
 						Message: "test-error-message",
 						Status:  http.StatusBadRequest,
 						Title:   "test-error-title",
@@ -515,7 +515,7 @@ func TestChildEndpoint_Search(t *testing.T) {
 					w.WriteHeader(http.StatusBadRequest)
 					w.Header().Set("Content-Type", "application/json")
 
-					err := apiError{
+					err := APIError{
 						Message: "test-error-message",
 						Status:  http.StatusBadRequest,
 						Title:   "test-error-title",
@@ -627,7 +627,7 @@ func TestChildEndpoint_Update(t *testing.T) {
 					w.WriteHeader(http.StatusBadRequest)
 					w.Header().Set("Content-Type", "application/json")
 
-					err := apiError{
+					err := APIError{
 						Message: "test-error-message",
 						Status:  http.StatusBadRequest,
 						Title:   "test-error-title",

--- a/pkg/api/endpoints_test.go
+++ b/pkg/api/endpoints_test.go
@@ -89,7 +89,7 @@ func TestEndpoint_Create(t *testing.T) {
 					w.WriteHeader(http.StatusBadRequest)
 					w.Header().Set("Content-Type", "application/json")
 
-					err := apiError{
+					err := APIError{
 						Message: "test-error-message",
 						Status:  http.StatusBadRequest,
 						Title:   "test-error-title",
@@ -181,7 +181,7 @@ func TestEndpoint_Delete(t *testing.T) {
 					w.WriteHeader(http.StatusBadRequest)
 					w.Header().Set("Content-Type", "application/json")
 
-					err := apiError{
+					err := APIError{
 						Message: "test-error-message",
 						Status:  http.StatusBadRequest,
 						Title:   "test-error-title",
@@ -276,7 +276,7 @@ func TestEndpoint_Get(t *testing.T) {
 					w.WriteHeader(http.StatusBadRequest)
 					w.Header().Set("Content-Type", "application/json")
 
-					err := apiError{
+					err := APIError{
 						Message: "test-error-message",
 						Status:  http.StatusBadRequest,
 						Title:   "test-error-title",
@@ -382,7 +382,7 @@ func TestEndpoint_Patch(t *testing.T) {
 					w.WriteHeader(http.StatusBadRequest)
 					w.Header().Set("Content-Type", "application/json")
 
-					err := apiError{
+					err := APIError{
 						Message: "test-error-message",
 						Status:  http.StatusBadRequest,
 						Title:   "test-error-title",
@@ -494,7 +494,7 @@ func TestEndpoint_Search(t *testing.T) {
 					w.WriteHeader(http.StatusBadRequest)
 					w.Header().Set("Content-Type", "application/json")
 
-					err := apiError{
+					err := APIError{
 						Message: "test-error-message",
 						Status:  http.StatusBadRequest,
 						Title:   "test-error-title",
@@ -599,7 +599,7 @@ func TestEndpoint_Update(t *testing.T) {
 					w.WriteHeader(http.StatusBadRequest)
 					w.Header().Set("Content-Type", "application/json")
 
-					err := apiError{
+					err := APIError{
 						Message: "test-error-message",
 						Status:  http.StatusBadRequest,
 						Title:   "test-error-title",

--- a/pkg/api/errors.go
+++ b/pkg/api/errors.go
@@ -5,13 +5,13 @@ import (
 	"time"
 )
 
-type apiError struct {
+type APIError struct {
 	Message string `json:"message"`
 	Status  int    `json:"status"`
 	Title   string `json:"title"`
 }
 
-func (e apiError) Error() string {
+func (e APIError) Error() string {
 	return fmt.Sprintf("%s (%d): %s", e.Title, e.Status, e.Message)
 }
 

--- a/pkg/api/requests.go
+++ b/pkg/api/requests.go
@@ -89,10 +89,10 @@ func retryRequest(ctx context.Context, a *api, method string, reqPath string, bo
 		// check to see if the response contains an error status
 		if res.StatusCode > 399 {
 			// attempt to unmarshal the body into an apiError
-			var apiErr apiError
+			var apiErr APIError
 			if err := json.Unmarshal(bdy, &apiErr); err != nil {
 				// the error is not an apiError, it is a string value
-				apiErr = apiError{
+				apiErr = APIError{
 					Message: string(bdy),
 					Status:  res.StatusCode,
 					Title:   res.Status,


### PR DESCRIPTION
Exposing the APIError struct so that consumers of the SDK can verify status on API response more easily (i.e. checking for 404s, etc.)