### PR TITLE
BookingID JSON serialization bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes in io-sdk-golang will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.3.15] - 2024-08-23
+
+ - Fixing disparity between the json declaration for bookingID here versus what's in booking-api
+
 ## [0.3.14] - 2024-08-14
 
 - Updated display-api models and added mediaProducts to display model

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SEMANTIC_VER=0.3.14+
+SEMANTIC_VER=0.3.15+
 BUILD_VER=$(shell git describe --always --long)
 PRE_RELEASE_VER=alpha
 

--- a/pkg/bookings/models.go
+++ b/pkg/bookings/models.go
@@ -9,7 +9,7 @@ type Booking struct {
 	EndDate     *time.Time      `json:"endDate,omitempty" bson:"endDate,omitempty"`
 	ExternalIDs []string        `json:"externalIDs,omitempty" bson:"externalIDs,omitempty"`
 	Filler      bool            `json:"filler,omitempty" bson:"filler,omitempty"`
-	ID          string          `json:"id,omitempty" bson:"id,omitempty"`
+	ID          string          `json:"bookingID,omitempty" bson:"bookingID,omitempty"`
 	OrderLineID string          `json:"orderLineID,omitempty" bson:"orderLineID,omitempty"`
 	Print       *PrintDetails   `json:"print,omitempty" bson:"print,omitempty"`
 	StartDate   *time.Time      `json:"startDate,omitempty" bson:"startDate,omitempty"`


### PR DESCRIPTION
There was a mismatch between how io-sdk marshaled the ID field on a booking, versus how booking api marshal's booking id.