### PR TITLE
initial implementation of support for http headers per request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,17 @@ All notable changes in io-sdk-golang will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.4.0] - 2024-09-27
+
+- Provided support for specifying headers when working with API clients
+
 ## [0.3.16] - 2024-09-25
 
- - [IOC-875] updating booking model
+- [IOC-875] updating booking model
 
 ## [0.3.15] - 2024-08-23
 
- - Fixing disparity between the json declaration for bookingID here versus what's in booking-api
+- Fixing disparity between the json declaration for bookingID here versus what's in booking-api
 
 ## [0.3.14] - 2024-08-14
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SEMANTIC_VER=0.3.17+
+SEMANTIC_VER=0.4.0+
 BUILD_VER=$(shell git describe --always --long)
 PRE_RELEASE_VER=alpha
 

--- a/pkg/api/childEndpoints.go
+++ b/pkg/api/childEndpoints.go
@@ -13,10 +13,11 @@ import (
 
 type ChildEndpoint[T any] struct {
 	a    *api
+	hdr  *http.Header
 	Path string
 }
 
-func NewChildEndpoint[T any](svc *Service, parentPath, childPath string) *ChildEndpoint[T] {
+func NewChildEndpoint[T any](svc *Service, parentPath, childPath string, hdr *http.Header) *ChildEndpoint[T] {
 	a := api{
 		Clnt: &http.Client{},
 		Svc:  svc,
@@ -24,6 +25,7 @@ func NewChildEndpoint[T any](svc *Service, parentPath, childPath string) *ChildE
 
 	return &ChildEndpoint[T]{
 		a:    &a,
+		hdr:  hdr,
 		Path: strings.Join([]string{parentPath, "/%s", childPath}, ""),
 	}
 }
@@ -31,6 +33,7 @@ func NewChildEndpoint[T any](svc *Service, parentPath, childPath string) *ChildE
 func (ce *ChildEndpoint[T]) request(ctx context.Context, method string, path string, body io.Reader, opts ...*Options) ([]byte, error) {
 	r, err := retryRequest(
 		ctx,
+		ce.hdr,
 		ce.a,
 		method,
 		path,

--- a/pkg/api/childEndpoints_test.go
+++ b/pkg/api/childEndpoints_test.go
@@ -24,6 +24,7 @@ func TestChildEndpoint_Create(t *testing.T) {
 	type fields struct {
 		parentPath string
 		childPath  string
+		headers    *http.Header
 	}
 	type args struct {
 		res      func(w http.ResponseWriter, r *http.Request)
@@ -42,6 +43,7 @@ func TestChildEndpoint_Create(t *testing.T) {
 			fields{
 				"/models",
 				"/children",
+				nil,
 			},
 			args{
 				func(w http.ResponseWriter, r *http.Request) {
@@ -76,6 +78,7 @@ func TestChildEndpoint_Create(t *testing.T) {
 			fields{
 				"/models",
 				"/children",
+				nil,
 			},
 			args{
 				func(w http.ResponseWriter, r *http.Request) {
@@ -113,6 +116,7 @@ func TestChildEndpoint_Create(t *testing.T) {
 				},
 				tt.fields.parentPath,
 				tt.fields.childPath,
+				tt.fields.headers,
 			)
 
 			// set a testing oauth token
@@ -143,6 +147,7 @@ func TestChildEndpoint_Delete(t *testing.T) {
 	type fields struct {
 		parentPath string
 		childPath  string
+		headers    *http.Header
 	}
 	type args struct {
 		res      func(w http.ResponseWriter, r *http.Request)
@@ -160,6 +165,7 @@ func TestChildEndpoint_Delete(t *testing.T) {
 			fields{
 				"/models",
 				"/children",
+				nil,
 			},
 			args{
 				func(w http.ResponseWriter, r *http.Request) {
@@ -175,6 +181,7 @@ func TestChildEndpoint_Delete(t *testing.T) {
 			fields{
 				"/models",
 				"/children",
+				nil,
 			},
 			args{
 				func(w http.ResponseWriter, r *http.Request) {
@@ -209,6 +216,7 @@ func TestChildEndpoint_Delete(t *testing.T) {
 				},
 				tt.fields.parentPath,
 				tt.fields.childPath,
+				tt.fields.headers,
 			)
 
 			// set a testing oauth token
@@ -234,6 +242,7 @@ func TestChildEndpoint_Get(t *testing.T) {
 	type fields struct {
 		parentPath string
 		childPath  string
+		headers    *http.Header
 	}
 	type args struct {
 		res      func(w http.ResponseWriter, r *http.Request)
@@ -252,6 +261,7 @@ func TestChildEndpoint_Get(t *testing.T) {
 			fields{
 				"/models",
 				"/children",
+				nil,
 			},
 			args{
 				func(w http.ResponseWriter, r *http.Request) {
@@ -277,6 +287,7 @@ func TestChildEndpoint_Get(t *testing.T) {
 			fields{
 				"/models",
 				"/children",
+				nil,
 			},
 			args{
 				func(w http.ResponseWriter, r *http.Request) {
@@ -312,6 +323,7 @@ func TestChildEndpoint_Get(t *testing.T) {
 				},
 				tt.fields.parentPath,
 				tt.fields.childPath,
+				tt.fields.headers,
 			)
 
 			// set a testing oauth token
@@ -343,6 +355,7 @@ func TestChildEndpoint_Patch(t *testing.T) {
 	type fields struct {
 		parentPath string
 		childPath  string
+		headers    *http.Header
 	}
 	type args struct {
 		res      func(w http.ResponseWriter, r *http.Request)
@@ -362,6 +375,7 @@ func TestChildEndpoint_Patch(t *testing.T) {
 			fields{
 				"/models",
 				"/children",
+				nil,
 			},
 			args{
 				func(w http.ResponseWriter, r *http.Request) {
@@ -390,6 +404,7 @@ func TestChildEndpoint_Patch(t *testing.T) {
 			fields{
 				"/models",
 				"/children",
+				nil,
 			},
 			args{
 				func(w http.ResponseWriter, r *http.Request) {
@@ -429,6 +444,7 @@ func TestChildEndpoint_Patch(t *testing.T) {
 				},
 				tt.fields.parentPath,
 				tt.fields.childPath,
+				tt.fields.headers,
 			)
 
 			// set a testing oauth token
@@ -459,6 +475,7 @@ func TestChildEndpoint_Search(t *testing.T) {
 	type fields struct {
 		parentPath string
 		childPath  string
+		headers    *http.Header
 	}
 	type args struct {
 		res      func(w http.ResponseWriter, r *http.Request)
@@ -476,6 +493,7 @@ func TestChildEndpoint_Search(t *testing.T) {
 			fields{
 				"/models",
 				"/children",
+				nil,
 			},
 			args{
 				func(w http.ResponseWriter, r *http.Request) {
@@ -509,6 +527,7 @@ func TestChildEndpoint_Search(t *testing.T) {
 			fields{
 				"/models",
 				"/children",
+				nil,
 			},
 			args{
 				func(w http.ResponseWriter, r *http.Request) {
@@ -543,6 +562,7 @@ func TestChildEndpoint_Search(t *testing.T) {
 				},
 				tt.fields.parentPath,
 				tt.fields.childPath,
+				tt.fields.headers,
 			)
 
 			// set a testing oauth token
@@ -574,6 +594,7 @@ func TestChildEndpoint_Update(t *testing.T) {
 	type fields struct {
 		parentPath string
 		childPath  string
+		headers    *http.Header
 	}
 	type args struct {
 		res      func(w http.ResponseWriter, r *http.Request)
@@ -593,6 +614,7 @@ func TestChildEndpoint_Update(t *testing.T) {
 			fields{
 				"/models",
 				"/children",
+				nil,
 			},
 			args{
 				func(w http.ResponseWriter, r *http.Request) {
@@ -621,6 +643,7 @@ func TestChildEndpoint_Update(t *testing.T) {
 			fields{
 				"/models",
 				"/children",
+				nil,
 			},
 			args{
 				func(w http.ResponseWriter, r *http.Request) {
@@ -660,6 +683,7 @@ func TestChildEndpoint_Update(t *testing.T) {
 				},
 				tt.fields.parentPath,
 				tt.fields.childPath,
+				tt.fields.headers,
 			)
 
 			// set a testing oauth token

--- a/pkg/api/endpoints.go
+++ b/pkg/api/endpoints.go
@@ -25,10 +25,11 @@ var retryAfterRE *regexp.Regexp = regexp.MustCompile(`retry after (\d+)s\: `)
 
 type Endpoint[T any] struct {
 	a    *api
+	hdr  *http.Header
 	Path string
 }
 
-func NewEndpoint[T any](svc *Service, path string) *Endpoint[T] {
+func NewEndpoint[T any](svc *Service, path string, hdr *http.Header) *Endpoint[T] {
 	a := api{
 		Clnt: &http.Client{},
 		Svc:  svc,
@@ -36,6 +37,7 @@ func NewEndpoint[T any](svc *Service, path string) *Endpoint[T] {
 
 	return &Endpoint[T]{
 		a:    &a,
+		hdr:  hdr,
 		Path: path,
 	}
 }
@@ -43,6 +45,7 @@ func NewEndpoint[T any](svc *Service, path string) *Endpoint[T] {
 func (e *Endpoint[T]) request(ctx context.Context, method string, path string, body io.Reader, opts ...*Options) ([]byte, error) {
 	r, err := retryRequest(
 		ctx,
+		e.hdr,
 		e.a,
 		method,
 		path,

--- a/pkg/api/endpoints_test.go
+++ b/pkg/api/endpoints_test.go
@@ -34,7 +34,8 @@ func TestEndpoint_Create(t *testing.T) {
 	var ts *httptest.Server
 
 	type fields struct {
-		path string
+		path    string
+		headers *http.Header
 	}
 	type args struct {
 		res func(w http.ResponseWriter, r *http.Request)
@@ -51,6 +52,7 @@ func TestEndpoint_Create(t *testing.T) {
 			"should properly create a model",
 			fields{
 				"/models",
+				nil,
 			},
 			args{
 				func(w http.ResponseWriter, r *http.Request) {
@@ -83,6 +85,7 @@ func TestEndpoint_Create(t *testing.T) {
 			"should properly handle an error response",
 			fields{
 				"/models",
+				nil,
 			},
 			args{
 				func(w http.ResponseWriter, r *http.Request) {
@@ -118,6 +121,7 @@ func TestEndpoint_Create(t *testing.T) {
 					Proto: u.Scheme,
 				},
 				tt.fields.path,
+				tt.fields.headers,
 			)
 
 			// set a testing oauth token
@@ -146,7 +150,8 @@ func TestEndpoint_Delete(t *testing.T) {
 	var ts *httptest.Server
 
 	type fields struct {
-		path string
+		path    string
+		headers *http.Header
 	}
 	type args struct {
 		res func(w http.ResponseWriter, r *http.Request)
@@ -162,6 +167,7 @@ func TestEndpoint_Delete(t *testing.T) {
 			"should properly delete a model",
 			fields{
 				"/models",
+				nil,
 			},
 			args{
 				func(w http.ResponseWriter, r *http.Request) {
@@ -175,6 +181,7 @@ func TestEndpoint_Delete(t *testing.T) {
 			"should properly handle an error response",
 			fields{
 				"/models",
+				nil,
 			},
 			args{
 				func(w http.ResponseWriter, r *http.Request) {
@@ -207,6 +214,7 @@ func TestEndpoint_Delete(t *testing.T) {
 					Proto: u.Scheme,
 				},
 				tt.fields.path,
+				tt.fields.headers,
 			)
 
 			// set a testing oauth token
@@ -230,7 +238,8 @@ func TestEndpoint_Get(t *testing.T) {
 	var ts *httptest.Server
 
 	type fields struct {
-		path string
+		path    string
+		headers *http.Header
 	}
 	type args struct {
 		res func(w http.ResponseWriter, r *http.Request)
@@ -247,6 +256,7 @@ func TestEndpoint_Get(t *testing.T) {
 			"should properly get a model",
 			fields{
 				"/models",
+				nil,
 			},
 			args{
 				func(w http.ResponseWriter, r *http.Request) {
@@ -270,6 +280,7 @@ func TestEndpoint_Get(t *testing.T) {
 			"should properly handle an error response",
 			fields{
 				"/models",
+				nil,
 			},
 			args{
 				func(w http.ResponseWriter, r *http.Request) {
@@ -303,6 +314,7 @@ func TestEndpoint_Get(t *testing.T) {
 					Proto: u.Scheme,
 				},
 				tt.fields.path,
+				tt.fields.headers,
 			)
 
 			// set a testing oauth token
@@ -332,7 +344,8 @@ func TestEndpoint_Patch(t *testing.T) {
 	var ts *httptest.Server
 
 	type fields struct {
-		path string
+		path    string
+		headers *http.Header
 	}
 	type args struct {
 		res func(w http.ResponseWriter, r *http.Request)
@@ -350,6 +363,7 @@ func TestEndpoint_Patch(t *testing.T) {
 			"should properly patch a model",
 			fields{
 				"/models",
+				nil,
 			},
 			args{
 				func(w http.ResponseWriter, r *http.Request) {
@@ -376,6 +390,7 @@ func TestEndpoint_Patch(t *testing.T) {
 			"should properly handle an error response",
 			fields{
 				"/models",
+				nil,
 			},
 			args{
 				func(w http.ResponseWriter, r *http.Request) {
@@ -413,6 +428,7 @@ func TestEndpoint_Patch(t *testing.T) {
 					Proto: u.Scheme,
 				},
 				tt.fields.path,
+				tt.fields.headers,
 			)
 
 			// set a testing oauth token
@@ -441,7 +457,8 @@ func TestEndpoint_Search(t *testing.T) {
 	var ts *httptest.Server
 
 	type fields struct {
-		path string
+		path    string
+		headers *http.Header
 	}
 	type args struct {
 		res func(w http.ResponseWriter, r *http.Request)
@@ -457,6 +474,7 @@ func TestEndpoint_Search(t *testing.T) {
 			"should properly get all models",
 			fields{
 				"/models",
+				nil,
 			},
 			args{
 				func(w http.ResponseWriter, r *http.Request) {
@@ -488,6 +506,7 @@ func TestEndpoint_Search(t *testing.T) {
 			"should properly handle an error response",
 			fields{
 				"/models",
+				nil,
 			},
 			args{
 				func(w http.ResponseWriter, r *http.Request) {
@@ -520,6 +539,7 @@ func TestEndpoint_Search(t *testing.T) {
 					Proto: u.Scheme,
 				},
 				tt.fields.path,
+				tt.fields.headers,
 			)
 
 			// set a testing oauth token
@@ -549,7 +569,8 @@ func TestEndpoint_Update(t *testing.T) {
 	var ts *httptest.Server
 
 	type fields struct {
-		path string
+		path    string
+		headers *http.Header
 	}
 	type args struct {
 		res func(w http.ResponseWriter, r *http.Request)
@@ -567,6 +588,7 @@ func TestEndpoint_Update(t *testing.T) {
 			"should properly post a model",
 			fields{
 				"/models",
+				nil,
 			},
 			args{
 				func(w http.ResponseWriter, r *http.Request) {
@@ -593,6 +615,7 @@ func TestEndpoint_Update(t *testing.T) {
 			"should properly handle an error response",
 			fields{
 				"/models",
+				nil,
 			},
 			args{
 				func(w http.ResponseWriter, r *http.Request) {
@@ -630,6 +653,7 @@ func TestEndpoint_Update(t *testing.T) {
 					Proto: u.Scheme,
 				},
 				tt.fields.path,
+				tt.fields.headers,
 			)
 
 			// set a testing oauth token

--- a/pkg/clients/childClients.go
+++ b/pkg/clients/childClients.go
@@ -3,6 +3,7 @@ package clients
 import (
 	"context"
 	"errors"
+	"net/http"
 
 	"github.com/clearchanneloutdoor/io-sdk-golang/internal"
 	"github.com/clearchanneloutdoor/io-sdk-golang/pkg/api"
@@ -11,6 +12,7 @@ import (
 
 type ChildClient[T any] struct {
 	ctx      context.Context
+	Headers  *http.Header
 	rep      api.ReadChildResource[T]
 	wep      api.WriteChildResouce[T]
 	writable bool
@@ -77,13 +79,17 @@ func NewChildClient[T any](ctx context.Context, svr string, parentResource, chil
 		return nil, errors.New("the API server URL is invalid")
 	}
 
-	ep := api.NewChildEndpoint[T](svc, parentResource, childResouce)
+	// create a header collection for the client
+	hdr := make(http.Header)
+
+	ep := api.NewChildEndpoint[T](svc, parentResource, childResouce, &hdr)
 
 	// determine if oauth supports write operations
 	for _, scope := range writeScopes {
 		if internal.ContainsValue(oauth2.Scopes, scope) {
 			return &ChildClient[T]{
 				ctx:      ctx,
+				Headers:  &hdr,
 				rep:      ep,
 				wep:      ep,
 				writable: true,

--- a/pkg/clients/clients.go
+++ b/pkg/clients/clients.go
@@ -3,6 +3,7 @@ package clients
 import (
 	"context"
 	"errors"
+	"net/http"
 
 	"github.com/clearchanneloutdoor/io-sdk-golang/internal"
 	"github.com/clearchanneloutdoor/io-sdk-golang/pkg/api"
@@ -11,6 +12,7 @@ import (
 
 type Client[T any] struct {
 	ctx      context.Context
+	Headers  *http.Header
 	rep      api.ReadResource[T]
 	wep      api.WriteResource[T]
 	writable bool
@@ -77,14 +79,18 @@ func NewClient[T any](ctx context.Context, svr string, resource string, oauth2 *
 		return nil, errors.New("the API server URL is invalid")
 	}
 
+	// create a header collection for the client
+	hdr := make(http.Header)
+
 	// create new endpoint
-	ep := api.NewEndpoint[T](svc, resource)
+	ep := api.NewEndpoint[T](svc, resource, &hdr)
 
 	// determine if oauth supports write operations
 	for _, scope := range writeScopes {
 		if internal.ContainsValue(oauth2.Scopes, scope) {
 			return &Client[T]{
 				ctx:      ctx,
+				Headers:  &hdr,
 				rep:      ep,
 				wep:      ep,
 				writable: true,


### PR DESCRIPTION
Adds support for providing http headers, if necessary, on API requests:

```go
package main

import (
	"fmt"

	"github.com/clearchanneloutdoor/io-sdk-golang/pkg/api"
	"github.com/clearchanneloutdoor/io-sdk-golang/pkg/displays"
	"golang.org/x/oauth2/clientcredentials"
)

func main() {
	// create a new client for retrieving displays
	client, err := displays.NewClient(
		context.Background(),
		&clientcredentials.Config{
			ClientID:     "replace-with-your-client-id",
			ClientSecret: "replace-with-your-client-secret",
			TokenURL:     "https://direct.cco.io/v2/token",
		})
	if err != nil {
		panic(err)
	}

	// set any applicable headers
	client.Headers.Set("X-CCO-Testing", "true")

	// get all digital displays that are 1080p
	res, err := client.Search(
		api.EmptyOptions().
			AddFilter("mediaProducts.digital", true).
			AddFilter("mediaProducts.digitalInfo.width", 1080))
	if err != nil {
		panic(err)
	}

	// print the results
	for _, d := range res.Data {
		fmt.Printf("%s\t%s\n", d.ID, d.Title)
	}
}
```