### PR TITLE
adjusting displays model to match the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,19 +5,28 @@ All notable changes in io-sdk-golang will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.5.0] - 2024-11-14
+
+- Updating and correcting displays model
+
 ## [0.4.9] - 2024-11-05
+
 - Fixing a few remaining details references
 
 ## [0.4.8] - 2024-11-05
+
 - Renamed Segment Details to Buy Types
 
 ## [0.4.7] - 2024-11-04
+
 - Add Cost field to booking model
 
 ## [0.4.6] - 2024-10-28
-Updates to the Order model: 
+
+Updates to the Order model:
+
 - Start and End dates are no longer pointers
-- promote Advertiser and Buyer to root level 
+- promote Advertiser and Buyer to root level
 - remove Employee FullName and add Number
 - add Canceled field to Market related data
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SEMANTIC_VER=0.4.9+
+SEMANTIC_VER=0.5.0+
 BUILD_VER=$(shell git describe --always --long)
 PRE_RELEASE_VER=alpha
 

--- a/pkg/displays/mediaProducts.go
+++ b/pkg/displays/mediaProducts.go
@@ -5,43 +5,49 @@ import (
 )
 
 type DigitalHoursOfOperation struct {
-	StartOffset       int `json:"startOffset" bson:"startOffset"`
-	DurationInMinutes int `json:"duration" bson:"duration"`
+	StartOffset       int `json:"startOffset"`
+	DurationInMinutes int `json:"duration"`
 }
 
 type MediaProduct struct {
-	Detail          string                       `json:"detail,omitempty" bson:"detail,omitempty"`
-	Digital         *bool                        `json:"digital,omitempty" bson:"digital,omitempty"`
-	DigitalInfo     *MediaProductDigitalInfo     `json:"digitalInfo,omitempty" bson:"digitalInfo,omitempty"`
-	ExternalIDs     []string                     `json:"externalIDs,omitempty" bson:"externalIDs,omitempty"`
-	ProductID       string                       `json:"productID,omitempty" bson:"productID,omitempty"`
-	Size            *Size                        `json:"size,omitempty" bson:"size,omitempty"`
-	Status          *MediaProductStatus          `json:"status,omitempty" bson:"status,omitempty"`
-	Type            string                       `json:"type,omitempty" bson:"type,omitempty"`
-	VisibleCreative *MediaProductVisibleCreative `json:"visibleCreative,omitempty" bson:"visibleCreative,omitempty"`
+	Code            *MediaProductCode            `json:"code,omitempty"`
+	Detail          string                       `json:"detail,omitempty"`
+	Digital         *bool                        `json:"digital,omitempty"`
+	DigitalInfo     *MediaProductDigitalInfo     `json:"digitalInfo,omitempty"`
+	ExternalIDs     []string                     `json:"externalIDs,omitempty"`
+	ProductID       string                       `json:"productID,omitempty"`
+	Size            *Size                        `json:"size,omitempty"`
+	Status          *MediaProductStatus          `json:"status,omitempty"`
+	Type            string                       `json:"type,omitempty"`
+	VisibleCreative *MediaProductVisibleCreative `json:"visibleCreative,omitempty"`
+}
+
+type MediaProductCode struct {
+	ProductCode string `json:"productCode,omitempty"`
+	TypeCode    string `json:"typeCode,omitempty"`
 }
 
 type MediaProductDigitalInfo struct {
-	Hours        []*DigitalHoursOfOperation `json:"hours,omitempty" bson:"hours,omitempty"`
-	Height       int                        `json:"height,omitempty" bson:"height,omitempty"`
-	SlotCount    int                        `json:"slotCount,omitempty" bson:"slotCount,omitempty"`
-	SlotDuration int                        `json:"slotDuration,omitempty" bson:"slotDuration,omitempty"`
-	Width        int                        `json:"width,omitempty" bson:"width,omitempty"`
+	Hours        []*DigitalHoursOfOperation `json:"hours,omitempty"`
+	Height       int                        `json:"height,omitempty"`
+	SlotCount    int                        `json:"slotCount,omitempty"`
+	SlotDuration int                        `json:"slotDuration,omitempty"`
+	Width        int                        `json:"width,omitempty"`
 }
 
 type MediaProductStatus struct {
-	Active     *bool                `json:"active,omitempty" bson:"active,omitempty"`
-	FinishDate *time.Time           `json:"finishDate,omitempty" bson:"finishDate,omitempty"`
-	LiveDate   *time.Time           `json:"liveDate,omitempty" bson:"liveDate,omitempty"`
-	Saleable   *bool                `json:"saleable,omitempty" bson:"saleable,omitempty"`
-	Sync       map[string]time.Time `json:"sync,omitempty" bson:"sync,omitempty"`
+	Active     *bool                `json:"active,omitempty"`
+	FinishDate *time.Time           `json:"finishDate,omitempty"`
+	LiveDate   *time.Time           `json:"liveDate,omitempty"`
+	Saleable   *bool                `json:"saleable,omitempty"`
+	Sync       map[string]time.Time `json:"sync,omitempty"`
 }
 
 type MediaProductVisibleCreative struct {
-	Height         float64          `json:"height,omitempty" bson:"height,omitempty"`
-	SupportedMedia []SupportedMedia `json:"supportedMedia,omitempty" bson:"supportedMedia,omitempty"`
-	UnitOfMeasure  string           `json:"unitOfMeasure,omitempty" bson:"unitOfMeasure,omitempty"`
-	Width          float64          `json:"width,omitempty" bson:"width,omitempty"`
+	Height         float64  `json:"height,omitempty"`
+	SupportedMedia []string `json:"supportedMedia,omitempty"`
+	UnitOfMeasure  string   `json:"unitOfMeasure,omitempty"`
+	Width          float64  `json:"width,omitempty"`
 }
 
 type SupportedMedia string

--- a/pkg/displays/models.go
+++ b/pkg/displays/models.go
@@ -5,67 +5,66 @@ import (
 )
 
 type Display struct {
-	AllowLocationBuy *bool                    `json:"allowLocationBuy,omitempty" bson:"allowLocationBuy,omitempty"`
-	Artery           *DisplayArtery           `json:"artery,omitempty" bson:"artery,omitempty"`
-	CreatedAt        *time.Time               `json:"createdAt,omitempty" bson:"createdAt,omitempty"`
-	Description      string                   `json:"description,omitempty" bson:"description,omitempty"`
-	Digital          *MediaProductDigitalInfo `json:"digital,omitempty" bson:"digital,omitempty"` // TODO: after import is complete, set bson hint to "-"
-	ExternalIDs      []string                 `json:"externalIDs,omitempty" bson:"externalIDs,omitempty"`
-	Facing           string                   `json:"facing,omitempty" bson:"facing,omitempty"`
-	GeoLocation      *GeoLocation             `json:"geolocation,omitempty" bson:"geolocation,omitempty"`
-	Height           *DisplayHeight           `json:"height,omitempty" bson:"height,omitempty"`
-	ID               string                   `json:"displayID" bson:"displayID"`
-	Illumination     *DisplayIllumination     `json:"illumination,omitempty" bson:"illumination,omitempty"`
-	Market           *DisplayMarket           `json:"market,omitempty" bson:"market,omitempty"`
-	MediaProducts    []*MediaProduct          `json:"mediaProducts,omitempty" bson:"mediaProducts,omitempty"`
-	ReadDirection    *string                  `json:"readDirection,omitempty" bson:"readDirection,omitempty"`
-	StreetSide       string                   `json:"streetSide,omitempty" bson:"streetSide,omitempty"`
-	Structure        *DisplayStructure        `json:"structure,omitempty" bson:"structure,omitempty"`
-	Title            string                   `json:"title,omitempty" bson:"title,omitempty"`
-	UpdatedAt        *time.Time               `json:"updatedAt,omitempty" bson:"updatedAt,omitempty"`
+	AllowLocationBuy *bool                    `json:"allowLocationBuy,omitempty"`
+	Artery           *DisplayArtery           `json:"artery,omitempty"`
+	CreatedAt        *time.Time               `json:"createdAt,omitempty"`
+	Description      string                   `json:"description,omitempty"`
+	Digital          *MediaProductDigitalInfo `json:"digital,omitempty"`
+	ExternalIDs      []string                 `json:"externalIDs,omitempty"`
+	Facing           string                   `json:"facing,omitempty"`
+	GeoLocation      *GeoLocation             `json:"geolocation,omitempty"`
+	Height           *DisplayHeight           `json:"height,omitempty"`
+	ID               string                   `json:"displayID"`
+	Illumination     *DisplayIllumination     `json:"illumination,omitempty"`
+	Market           *DisplayMarket           `json:"market,omitempty"`
+	MediaProducts    []*MediaProduct          `json:"mediaProducts,omitempty"`
+	ReadDirection    *string                  `json:"readDirection,omitempty"`
+	StreetSide       string                   `json:"streetSide,omitempty"`
+	Structure        *DisplayStructure        `json:"structure,omitempty"`
+	Title            string                   `json:"title,omitempty"`
+	UpdatedAt        *time.Time               `json:"updatedAt,omitempty"`
 }
 
 type DisplayArtery struct {
-	Primary   string `json:"primary,omitempty" bson:"primary,omitempty"`
-	Secondary string `json:"secondary,omitempty" bson:"secondary,omitempty"`
+	Primary   string `json:"primary,omitempty"`
+	Secondary string `json:"secondary,omitempty"`
 }
 
 type DisplayHeight struct {
-	FromGround    float64 `json:"fromGround,omitempty" bson:"fromGround,omitempty"`
-	UnitOfMeasure string  `json:"unitOfMeasure,omitempty" bson:"unitOfMeasure,omitempty"`
+	FromGround    float64 `json:"fromGround,omitempty"`
+	UnitOfMeasure string  `json:"unitOfMeasure,omitempty"`
 }
 
 type DisplayIllumination struct {
-	Hours       int  `json:"hours,omitempty" bson:"hours,omitempty"`
-	Illuminated bool `json:"illuminated,omitempty" bson:"illuminated,omitempty"`
+	Hours       int  `json:"hours,omitempty"`
+	Illuminated bool `json:"illuminated,omitempty"`
 }
 
 type DisplayMarket struct {
-	ExternalIDs []string `json:"externalIDs,omitempty" bson:"externalIDs,omitempty"`
-	ID          string   `json:"marketID,omitempty" bson:"marketID,omitempty"`
-	CBSACode    string   `json:"cbsaCode,omitempty" bson:"cbsaCode,omitempty"`
-	CBSAName    string   `json:"cbsaName,omitempty" bson:"cbsaName,omitempty"`
-	DMACode     string   `json:"dmaCode,omitempty" bson:"dmaCode,omitempty"`
-	DMAName     string   `json:"dmaName,omitempty" bson:"dmaName,omitempty"`
-	Name        string   `json:"name,omitempty" bson:"name,omitempty"`
-	Number      string   `json:"number,omitempty" bson:"number,omitempty"`
+	ExternalIDs []string `json:"externalIDs,omitempty"`
+	ID          string   `json:"marketID,omitempty"`
+	CBSACode    string   `json:"cbsaCode,omitempty"`
+	CBSAName    string   `json:"cbsaName,omitempty"`
+	DMACode     string   `json:"dmaCode,omitempty"`
+	DMAName     string   `json:"dmaName,omitempty"`
+	Name        string   `json:"name,omitempty"`
+	Number      string   `json:"number,omitempty"`
 }
 
 type DisplayStructure struct {
 	ExternalIDs []string `json:"externalIDs,omitempty"`
-	// ID          string   `json:"structureID,omitempty"`
 }
 
 type Size struct {
-	Height        float64 `json:"height,omitempty" bson:"height,omitempty"`
-	UnitOfMeasure string  `json:"unitOfMeasure,omitempty" bson:"unitOfMeasure,omitempty"`
-	Width         float64 `json:"width,omitempty" bson:"width,omitempty"`
+	Height        float64 `json:"height,omitempty"`
+	UnitOfMeasure string  `json:"unitOfMeasure,omitempty"`
+	Width         float64 `json:"width,omitempty"`
 }
 
 type GeoLocation struct {
 	Coordinates struct {
-		Latitude  float64 `json:"latitude" bson:"latitude"`
-		Longitude float64 `json:"longitude" bson:"longitude"`
-	} `json:"coordinates,omitempty" bson:"coordinates,omitempty"`
-	Type string `json:"type,omitempty" bson:"type,omitempty"`
+		Latitude  float64 `json:"latitude"`
+		Longitude float64 `json:"longitude"`
+	} `json:"coordinates,omitempty"`
+	Type string `json:"type,omitempty"`
 }


### PR DESCRIPTION
Added the `code` sub-document to the `mediaProducts` array and adjusted all arrays of typed strings to just be strings (makes it a lot easier on the consumer of the SDK).