### PR TITLE
added buyType struct to bookings model, changelog and semver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes in io-sdk-golang will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.5.7] - 2025-05-23
+
+- add BuyType struct to the bookings model
+
 ## [0.5.6] - 2025-05-20
 
 - add fullMarket & fullMarketPolitical mod types to pricing models

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SEMANTIC_VER=0.5.6+
+SEMANTIC_VER=0.5.7+
 BUILD_VER=$(shell git describe --always --long)
 PRE_RELEASE_VER=alpha
 

--- a/pkg/bookings/models.go
+++ b/pkg/bookings/models.go
@@ -4,8 +4,10 @@ import (
 	"time"
 )
 
-type BookingStatus string
-type LifecycleEvent string
+type (
+	BookingStatus  string
+	LifecycleEvent string
+)
 
 const (
 	Draft    BookingStatus = "Draft"
@@ -15,7 +17,9 @@ const (
 )
 
 type Booking struct {
-	ID           string           `json:"bookingID,omitempty" bson:"bookingID,omitempty"`
+	ID      string   `json:"bookingID,omitempty" bson:"bookingID,omitempty"`
+	BuyType *BuyType `json:"buyType,omitempty" bson:"buyType,omitempty"`
+	// todo: remove buyTypeID once dependency on buy-type-api is removed from all services
 	BuyTypeID    string           `json:"buyTypeID,omitempty" bson:"buyTypeID,omitempty"`
 	Cost         *float32         `json:"cost,omitempty"`
 	CreatedAt    time.Time        `json:"createdAt,omitempty" bson:"createdAt,omitempty"`
@@ -33,6 +37,12 @@ type Booking struct {
 	Status       BookingStatus    `json:"status,omitempty" bson:"status,omitempty"`
 	UpdatedAt    time.Time        `json:"updatedAt,omitempty" bson:"updatedAt,omitempty"`
 	Waitlisted   *bool            `json:"waitlisted,omitempty" bson:"waitlisted,omitempty"`
+}
+
+type BuyType struct {
+	Deliverable      string `json:"deliverable,omitempty" bson:"deliverable,omitempty"`
+	Flexibility      string `json:"flexibility,omitempty" bson:"flexibility,omitempty"`
+	RevenueSpecifier string `json:"revenueSpecifier,omitempty" bson:"revenueSpecifier,omitempty"`
 }
 
 type MediaProduct struct {


### PR DESCRIPTION
Update bookings model with BuyType struct for use in booking-sync-svc and booking-api