### PR TITLE
Feature/ioc 1188 buytype enum changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes in io-sdk-golang will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.5.8] - 2025-05-28
+
+- changed flexibility and revenueSpecifier in buyType model to enums
+
 ## [0.5.7] - 2025-05-23
 
 - add BuyType struct to the bookings model

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SEMANTIC_VER=0.5.7+
+SEMANTIC_VER=0.5.8+
 BUILD_VER=$(shell git describe --always --long)
 PRE_RELEASE_VER=alpha
 

--- a/pkg/bookings/models.go
+++ b/pkg/bookings/models.go
@@ -58,14 +58,15 @@ const (
 type RevenueSpecifier string
 
 const (
-	Trade    RevenueSpecifier = "Trade"
 	Bonus    RevenueSpecifier = "Bonus"
-	Lessor   RevenueSpecifier = "Lessor"
-	PSA      RevenueSpecifier = "PSA" // lives on order, not booking, may still come through on an orderline message and will need to be parsed correctly
-	MakeGood RevenueSpecifier = "Make Good"
-	RFR      RevenueSpecifier = "Right of First Refusal"
+	Empty    RevenueSpecifier = ""
 	FBI      RevenueSpecifier = "FBI"
+	Lessor   RevenueSpecifier = "Lessor"
+	MakeGood RevenueSpecifier = "Make Good"
 	Override RevenueSpecifier = "Override"
+	PSA      RevenueSpecifier = "PSA" // lives on order, not booking, may still come through on an orderline message and will need to be parsed correctly
+	RFR      RevenueSpecifier = "Right of First Refusal"
+	Trade    RevenueSpecifier = "Trade"
 )
 
 type MediaProduct struct {

--- a/pkg/bookings/models.go
+++ b/pkg/bookings/models.go
@@ -40,10 +40,33 @@ type Booking struct {
 }
 
 type BuyType struct {
-	Deliverable      string `json:"deliverable,omitempty" bson:"deliverable,omitempty"`
-	Flexibility      string `json:"flexibility,omitempty" bson:"flexibility,omitempty"`
-	RevenueSpecifier string `json:"revenueSpecifier,omitempty" bson:"revenueSpecifier,omitempty"`
+	Deliverable      string           `json:"deliverable,omitempty" bson:"deliverable,omitempty"`
+	Flexibility      Flexibility      `json:"flexibility,omitempty" bson:"flexibility,omitempty"`
+	RevenueSpecifier RevenueSpecifier `json:"revenueSpecifier,omitempty" bson:"revenueSpecifier,omitempty"`
 }
+
+// flexibility enums for Fixed, Flexible, FullMarketFixed, FullMarketFlexible
+type Flexibility string
+
+const (
+	Fixed    Flexibility = "Fixed"
+	Flexible Flexibility = "Flexible"
+	NA       Flexibility = "N/A" // for override bonus only
+)
+
+// enums for Trade, Bonus, Lessor, PSA, Make Good, RFR, FBI, "", Override
+type RevenueSpecifier string
+
+const (
+	Trade    RevenueSpecifier = "Trade"
+	Bonus    RevenueSpecifier = "Bonus"
+	Lessor   RevenueSpecifier = "Lessor"
+	PSA      RevenueSpecifier = "PSA" // lives on order, not booking, may still come through on an orderline message and will need to be parsed correctly
+	MakeGood RevenueSpecifier = "Make Good"
+	RFR      RevenueSpecifier = "Right of First Refusal"
+	FBI      RevenueSpecifier = "FBI"
+	Override RevenueSpecifier = "Override"
+)
 
 type MediaProduct struct {
 	ProductCode string `json:"productCode,omitempty" bson:"productCode,omitempty"`


### PR DESCRIPTION
changed flexibility and revenueSpecifier to enums per feedback from @Clairevf 