### PR TITLE
IOC-1240

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes in io-sdk-golang will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.7.10] - 2025-07-24
+
+- [IOC-1240] updated default token expiration overlap setting to help ease the unauthorized token errors we keep seeing in production
+
 ## [0.7.9] - 2025-07-16
 
 - [IOC-1239] update booking model with fulfilled data

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SEMANTIC_VER=0.7.9+
+SEMANTIC_VER=0.7.10+
 BUILD_VER=$(shell git describe --always --long)
 PRE_RELEASE_VER=alpha
 

--- a/pkg/api/requests.go
+++ b/pkg/api/requests.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	defaultMaxAttempts            uint          = 5
-	defaultTokenExpirationOverlap time.Duration = 5 * time.Minute
+	defaultTokenExpirationOverlap time.Duration = 15 * time.Minute
 )
 
 func ensureBearerToken(ctx context.Context, a *api) (string, error) {


### PR DESCRIPTION
updated default token expiration overlap to 15 minutes to help alleviate token expiration errors that keep occurring 