### PR TITLE
Feature/ioc 1253 booking model updates july 2025

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes in io-sdk-golang will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.7.11] - 2025-07-28
+
+- [IOC-1253] updated booking model to match pointered fields and added externalIDs to networkDetails
+
 ## [0.7.10] - 2025-07-24
 
 - [IOC-1240] updated default token expiration overlap setting to help ease the unauthorized token errors we keep seeing in production

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SEMANTIC_VER=0.7.10+
+SEMANTIC_VER=0.7.11+
 BUILD_VER=$(shell git describe --always --long)
 PRE_RELEASE_VER=alpha
 

--- a/pkg/bookings/models.go
+++ b/pkg/bookings/models.go
@@ -5,7 +5,6 @@ import (
 )
 
 type Booking struct {
-	ID           string           `json:"bookingID"`
 	BuyType      *BuyType         `json:"buyType,omitempty"`
 	Cost         *float64         `json:"cost,omitempty"`
 	CreatedAt    time.Time        `json:"createdAt"`
@@ -13,7 +12,8 @@ type Booking struct {
 	Display      *DisplayDetails  `json:"display,omitempty"`
 	EndDate      time.Time        `json:"endDate,omitempty"`
 	ExternalIDs  []string         `json:"externalIDs,omitempty"`
-	Filler       bool             `json:"filler,omitempty"`
+	Filler       *bool            `json:"filler,omitempty"`
+	ID           string           `json:"bookingID"`
 	Market       *Market          `json:"market,omitempty"`
 	MediaProduct *MediaProduct    `json:"mediaProduct,omitempty"`
 	Network      *NetworkDetails  `json:"network,omitempty"`
@@ -36,13 +36,13 @@ type BuyType struct {
 }
 
 type DigitalDaysToPlay struct {
-	Sunday    bool `json:"sunday"`
-	Monday    bool `json:"monday"`
-	Tuesday   bool `json:"tuesday"`
-	Wednesday bool `json:"wednesday"`
-	Thursday  bool `json:"thursday"`
-	Friday    bool `json:"friday"`
-	Saturday  bool `json:"saturday"`
+	Sunday    *bool `json:"sunday"`
+	Monday    *bool `json:"monday"`
+	Tuesday   *bool `json:"tuesday"`
+	Wednesday *bool `json:"wednesday"`
+	Thursday  *bool `json:"thursday"`
+	Friday    *bool `json:"friday"`
+	Saturday  *bool `json:"saturday"`
 }
 
 type DisplayDetails struct {
@@ -66,6 +66,7 @@ type NetworkDetails struct {
 	DailyEndTime      string             `json:"dailyEndTime,omitempty"`
 	DailyStartTime    string             `json:"dailyStartTime,omitempty"`
 	DaysToPlay        *DigitalDaysToPlay `json:"daysToPlay,omitempty"`
+	ExternalIDs       []string           `json:"externalIDs,omitempty"`
 	Frequency         int                `json:"frequency,omitempty"`
 	NetworkID         string             `json:"networkID,omitempty"`
 	NumberOfSlots     int                `json:"numberOfSlots,omitempty"`
@@ -81,7 +82,7 @@ type QuantityCustomDetails struct {
 
 type QuantityDetails struct {
 	Custom            *QuantityCustomDetails     `json:"custom,omitempty"`
-	Fulfilled         []Fulfilled                `json:"fulfilled,omitempty"`
+	Fulfilled         []*Fulfilled               `json:"fulfilled,omitempty"`
 	FullMarket        *QuantityFullMarketDetails `json:"fullMarket,omitempty"`
 	RequestedQuantity int                        `json:"requestedQuantity,omitempty"`
 }

--- a/pkg/buyTypes/models.go
+++ b/pkg/buyTypes/models.go
@@ -4,6 +4,7 @@ import (
 	"time"
 )
 
+// todo verify system wide deprecation (with deprecation of buy-type-api) and remove this package
 type BuyType struct {
 	Attributes  *BuyTypeAttributes `json:"attributes,omitempty"`
 	Category    string             `json:"category,omitempty"`


### PR DESCRIPTION
- added externalIDs to networkDetails
- alphabetized and pointered fields to match model in booking-api

NOTE: the pointering may be a breaking change for booking-sync-svc